### PR TITLE
Modernize NuGet packages to fit Akka.NET 1.5.18

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -14,19 +14,14 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET 7 SDK 7.0.x'
+        displayName: 'Use .NET 8 SDK 8.0.x'
         inputs:
-          version: 7.0.x
+          version: 8.0.x
       - task: UseDotNet@2
         displayName: 'Use .NET Core Runtime 6.0.x'
         inputs:
           packageType: runtime
           version: 6.0.x
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3.1.x'
-        inputs:
-          packageType: runtime
-          version: 3.1.x
       - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
         clean: false  # whether to fetch clean each time
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules

--- a/src/Akka.MultiNode.SampleMultiNodeTests/Akka.MultiNode.SampleMultiNodeTests.csproj
+++ b/src/Akka.MultiNode.SampleMultiNodeTests/Akka.MultiNode.SampleMultiNodeTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>$(NetCoreTestVersion);$(NetTestVersion)</TargetFrameworks>
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Akka.MultiNode.TestAdapter.Tests/Akka.MultiNode.TestAdapter.Tests.csproj
+++ b/src/Akka.MultiNode.TestAdapter.Tests/Akka.MultiNode.TestAdapter.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>$(NetCoreTestVersion);$(NetTestVersion)</TargetFrameworks>
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Akka.MultiNode.TestAdapter.Tests/TestSink.cs
+++ b/src/Akka.MultiNode.TestAdapter.Tests/TestSink.cs
@@ -12,11 +12,12 @@ using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using LongLivedMarshalByRefObject = Xunit.Sdk.LongLivedMarshalByRefObject;
 using TestCaseStarting = Xunit.Sdk.TestCaseStarting;
 
 namespace Akka.MultiNode.TestAdapter.Tests
 {
-    internal class TestSink : IMessageSink, IDisposable
+    internal class TestSink : LongLivedMarshalByRefObject, IMessageSink, IDisposable
     {
         public ManualResetEvent Finished { get; }= new ManualResetEvent(false);
 

--- a/src/Akka.MultiNode.TestAdapter/Internal/Discovery.cs
+++ b/src/Akka.MultiNode.TestAdapter/Internal/Discovery.cs
@@ -11,10 +11,11 @@ using System.Linq;
 using System.Threading;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using LongLivedMarshalByRefObject = Xunit.LongLivedMarshalByRefObject;
 
 namespace Akka.MultiNode.TestAdapter.Internal
 {
-    internal class Discovery : IMessageSink, IDisposable
+    internal class Discovery : LongLivedMarshalByRefObject, IMessageSink, IDisposable
     {
         // There can be multiple fact attributes in a single class, but our convention
         // limits them to 1 fact attribute per test class

--- a/src/Akka.MultiNode.TestAdapter/NodeRunner/ExecutorSink.cs
+++ b/src/Akka.MultiNode.TestAdapter/NodeRunner/ExecutorSink.cs
@@ -12,10 +12,11 @@ using Akka.MultiNode.TestAdapter.Internal.Sinks;
 using Xunit;
 using Xunit.Abstractions;
 using IMessageSink = Xunit.Abstractions.IMessageSink;
+using LongLivedMarshalByRefObject = Xunit.Sdk.LongLivedMarshalByRefObject;
 
 namespace Akka.MultiNode.TestAdapter.NodeRunner
 {
-    internal class ExecutorSink : IMessageSink, IDisposable
+    internal class ExecutorSink : LongLivedMarshalByRefObject, IMessageSink, IDisposable
     {
         public bool Passed { get; private set; }
         public ManualResetEvent Finished { get; private set; }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,20 +1,21 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <XUnitVersion>2.5.3</XUnitVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Akka.Cluster.TestKit" Version="1.5.13" />
+    <PackageVersion Include="Akka.Cluster.TestKit" Version="1.5.18" />
     <PackageVersion Include="TeamCity.ServiceMessages" Version="4.1.1" />
     <PackageVersion Include="System.CodeDom" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="xunit.runner.utility" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.utility" Version="$(XUnitVersion)" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="$(XUnitVersion)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->


### PR DESCRIPTION
Modernize NuGet packages to keep in-step with Akka.NET 1.5.18

## Changes

* Drop netcoreapp3.1 test target
* Bump Akka.NET to 1.5.18
* Bump xunit to 2.5.3 (lock-step with Akka.NET 1.5.18)
* Synchronize xunit and xunit.runner.utility version