### PR TITLE
Fix TRX NRE bug

### DIFF
--- a/src/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestCaseRunner.cs
+++ b/src/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestCaseRunner.cs
@@ -143,12 +143,14 @@ akka.io.tcp {{
             SinkCoordinator = TestRunSystem.ActorOf(Props.Create(()
                 => new SinkCoordinator(sinks)), "sinkCoordinator");
 
+            await SinkCoordinator.Ask<SinkCoordinator.Ready>(Sinks.SinkCoordinator.Ready.Instance);
+            
             var tcpLogger = TestRunSystem.ActorOf(Props.Create(() => new TcpLoggingServer(SinkCoordinator)), "TcpLogger");
             var listenEndpoint = new IPEndPoint(IPAddress.Parse(Options.ListenAddress), Options.ListenPort);
             TestRunSystem.Tcp().Tell(new Tcp.Bind(tcpLogger, listenEndpoint), sender: tcpLogger);
 
-            PublishRunnerMessage($"Starting test {TestCase.DisplayName}");
             StartNewSpec();
+            PublishRunnerMessage($"Starting test {TestCase.DisplayName}");
 
             var timelineCollector = TestRunSystem.ActorOf(Props.Create(() => new TimelineLogCollectorActor(Options.AppendLogOutput)));
             

--- a/src/Akka.MultiNode.TestAdapter/Internal/Sinks/IMessageSink.cs
+++ b/src/Akka.MultiNode.TestAdapter/Internal/Sinks/IMessageSink.cs
@@ -25,7 +25,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Sinks
         /// 
         /// Typically called at the beginning of a test run.
         /// </summary>
-        void Open(ActorSystem context);
+        Task Open(ActorSystem context);
 
         /// <summary>
         /// Flag that determines if <see cref="Open"/> has been successfully called or not.

--- a/src/Akka.MultiNode.TestAdapter/Internal/Sinks/MessageSink.cs
+++ b/src/Akka.MultiNode.TestAdapter/Internal/Sinks/MessageSink.cs
@@ -33,7 +33,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Sinks
 
         #region Flow Control
 
-        public void Open(ActorSystem context)
+        public async Task Open(ActorSystem context)
         {
             //Do nothing
             if(IsClosed || IsOpen) return;
@@ -42,6 +42,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Sinks
 
             //Start the TestCoordinatorActor
             MessageSinkActorRef = context.ActorOf(MessageSinkActorProps);
+            await MessageSinkActorRef.Ask<SinkCoordinator.Ready>(SinkCoordinator.Ready.Instance);
         }
 
         public bool IsOpen { get; private set; }
@@ -55,7 +56,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Sinks
         public async Task<bool> Close(ActorSystem context)
         {
             //Test run has already been closed or hasn't started
-            if (!IsOpen || IsClosed) return await Task.FromResult(false);
+            if (!IsOpen || IsClosed) return false;
 
             IsOpen = false;
             IsClosed = true;

--- a/src/Akka.MultiNode.TestAdapter/Internal/Sinks/MessageSinkActor.cs
+++ b/src/Akka.MultiNode.TestAdapter/Internal/Sinks/MessageSinkActor.cs
@@ -54,6 +54,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Sinks
         /// </summary>
         private void SetReceive()
         {
+            Receive<SinkCoordinator.Ready>(HandleReady);
             Receive<BeginNewSpec>(HandleNewSpec);
             Receive<EndSpec>(HandleEndSpec);
             Receive<LogMessageFragmentForNode>(HandleNodeMessageFragment);
@@ -73,6 +74,8 @@ namespace Akka.MultiNode.TestAdapter.Internal.Sinks
         /// </summary>
         protected abstract void AdditionalReceives();
 
+        private void HandleReady(SinkCoordinator.Ready ready) => Sender.Tell(ready);
+        
         protected abstract void HandleNewSpec(BeginNewSpec newSpec);
 
         protected abstract void HandleEndSpec(EndSpec endSpec);


### PR DESCRIPTION
## Fixes

Akka MNTR suite has been plagued with these error logs:
```
[ERROR][04/18/2024 15:08:26.116Z][Thread 0016][akka://TestRunnerLogging/user/$c] Object reference not set to an instance of an object.
Cause: System.NullReferenceException: Object reference not set to an instance of an object.
   at Akka.MultiNode.TestAdapter.Internal.TrxReporter.TrxSinkActor.HandleNodeSpecPass(NodeCompletedSpecWithSuccess nodeSuccess)
   at lambda_method46(Closure, Object, Action`1, Action`1, Action`1, Action`1, Action`1, Action`1, Action`1, Action`1, Action`1, Action`1)
   at Akka.Tools.MatchHandler.PartialHandlerArgumentsCapture`11.Handle(T value) in D:\a\1\s\src\core\Akka\Util\MatchHandler\PartialHandlerArgumentsCapture.cs:line 451
   at Akka.Actor.ReceiveActor.ExecutePartialMessageHandler(Object message, PartialAction`1 partialAction) in D:\a\1\s\src\core\Akka\Actor\ReceiveActor.cs:line 78
   at Akka.Actor.ReceiveActor.OnReceive(Object message) in D:\a\1\s\src\core\Akka\Actor\ReceiveActor.cs:line 73
   at Akka.Actor.UntypedActor.Receive(Object message) in D:\a\1\s\src\core\Akka\Actor\UntypedActor.cs:line 26
   at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message) in D:\a\1\s\src\core\Akka\Actor\ActorBase.cs:line 214
   at Akka.Actor.ActorCell.ReceiveMessage(Object message) in D:\a\1\s\src\core\Akka\Actor\ActorCell.DefaultMessages.cs:line 185
   at Akka.Actor.ActorCell.Invoke(Envelope envelope) in D:\a\1\s\src\core\Akka\Actor\ActorCell.DefaultMessages.cs:line 87
```

This is caused by the async creation delay of `IMessageSink` actors, they're not yet created when the first few messages were sent to the `SinkCoordinator`.

## Changes

Make sure that all sinks inside the `SinkCoordinator` were up and ready to receive test messages before we start to send them any messages.