### PR TITLE
Update RELEASE_NOTES.md for 1.5.19 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.19 April 12 2024
+#### 1.5.19 April 20 2024
 
 * [Updated Akka.NET to 1.5.19](https://github.com/akkadotnet/akka.net/releases/tag/1.5.19)
 * [Fix TRX exporter NullReferenceException bug](https://github.com/akkadotnet/Akka.MultiNodeTestRunner/pull/234)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.19 April 12 2024
+
+* [Updated Akka.NET to 1.5.19](https://github.com/akkadotnet/akka.net/releases/tag/1.5.19)
+* [Fix TRX exporter NullReferenceException bug](https://github.com/akkadotnet/Akka.MultiNodeTestRunner/pull/234)
+
 #### 1.5.18 April 12 2024
 
 * [Updated Akka.NET to 1.5.18](https://github.com/akkadotnet/akka.net/releases/tag/1.5.18)


### PR DESCRIPTION
## 1.5.19 April 20 2024

* [Updated Akka.NET to 1.5.19](https://github.com/akkadotnet/akka.net/releases/tag/1.5.19)
* [Fix TRX exporter NullReferenceException bug](https://github.com/akkadotnet/Akka.MultiNodeTestRunner/pull/234)