### PR TITLE
Update RELEASE_NOTES.md for 1.5.24 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.24 June 7 2024
+
+* [Updated Akka.NET to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
+* [Fix CVE-2018-8292](https://github.com/akkadotnet/Akka.MultiNodeTestRunner/pull/244)
+
 #### 1.5.19 April 20 2024
 
 * [Updated Akka.NET to 1.5.19](https://github.com/akkadotnet/akka.net/releases/tag/1.5.19)


### PR DESCRIPTION
## 1.5.24 June 7 2024

* [Updated Akka.NET to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
* [Fix CVE-2018-8292](https://github.com/akkadotnet/Akka.MultiNodeTestRunner/pull/244)