### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.28</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -24,9 +24,7 @@
   </ItemGroup>
   <!-- NuGet .nupkg options -->
   <PropertyGroup>
-    <PackageReleaseNotes>1.5.25 June 17 2024
-
-* [Updated Akka.NET to 1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25)</PackageReleaseNotes>
+    <PackageReleaseNotes>* [Upgraded to Akka.Cluster.TestKit v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;test</PackageTags>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.MultiNodeTestRunner</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Akka.Cluster.TestKit" Version="1.5.51" />
+    <PackageVersion Include="Akka.Cluster.TestKit" Version="1.5.59" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="TeamCity.ServiceMessages" Version="4.1.1" />
     <PackageVersion Include="System.CodeDom" Version="9.0.8" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.59 January 26 2025 ####
+
+* [Upgraded to Akka.Cluster.TestKit v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.40 April 10th 2024 ####
 
 * [Upgraded to Akka.Cluster.TestKit v1.5.40](https://github.com/akkadotnet/akka.net/releases/tag/1.5.40)


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)