### PR TITLE
Fix: Use windows-2022 in release pipeline

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -2,7 +2,7 @@
 # See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
 
 pool:
-  vmImage: windows-latest
+  vmImage: windows-2022
   demands: Cmd
 
 trigger:


### PR DESCRIPTION
Azure DevOps windows-latest bug workaround.