### PR TITLE
Bump AkkaVersion to 1.5.60

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.59</VersionPrefix>
+    <VersionPrefix>1.5.60</VersionPrefix>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -24,7 +24,7 @@
   </ItemGroup>
   <!-- NuGet .nupkg options -->
   <PropertyGroup>
-    <PackageReleaseNotes>* [Upgraded to Akka.Cluster.TestKit v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
+    <PackageReleaseNotes>* [Upgraded to Akka.Cluster.TestKit v1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;test</PackageTags>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.MultiNodeTestRunner</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Akka.Cluster.TestKit" Version="1.5.59" />
+    <PackageVersion Include="Akka.Cluster.TestKit" Version="1.5.60" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="TeamCity.ServiceMessages" Version="4.1.1" />
     <PackageVersion Include="System.CodeDom" Version="9.0.8" />


### PR DESCRIPTION
## Summary

Updates Akka.MultiNodeTestRunner to use Akka.NET 1.5.60 (from 1.5.59).

## Changes

- Updated `Akka.Cluster.TestKit` dependency from 1.5.59 to 1.5.60
- Updated package version to 1.5.60
- Updated release notes

## Test Plan

- [x] Build succeeds
- [x] All tests pass